### PR TITLE
Remove "install app", "open app" and other buttons 

### DIFF
--- a/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/TwitterWrapper.java
+++ b/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/TwitterWrapper.java
@@ -227,6 +227,7 @@ public class TwitterWrapper extends BaseTwitterWebViewActivity {
         boolean blockImages = mSharedPreferences.getBoolean(TwitterPreferences.BLOCK_IMAGES, false);
         boolean allowCheckins = mSharedPreferences.getBoolean(TwitterPreferences.ALLOW_CHECKINS, false);
         boolean enableProxy = mSharedPreferences.getBoolean(TwitterPreferences.KEY_PROXY_ENABLED, false);
+        boolean blockAndroidRelatedAnnoyances = mSharedPreferences.getBoolean(TwitterPreferences.KEY_BLOCK_ANDROID_ANNOYANCES, false);
         String proxyHost = mSharedPreferences.getString(TwitterPreferences.KEY_PROXY_HOST, null);
         String proxyPort = mSharedPreferences.getString(TwitterPreferences.KEY_PROXY_PORT, null);
 
@@ -234,6 +235,7 @@ public class TwitterWrapper extends BaseTwitterWebViewActivity {
         setAllowCheckins(allowCheckins);
         setAllowAnyDomain(anyDomain);
         setBlockImages(blockImages);
+        setBlockAnnoyances(blockAndroidRelatedAnnoyances);
 
         if (enableProxy && !TextUtils.isEmpty(proxyHost) && !TextUtils.isEmpty(proxyPort)) {
             int proxyPortInt = -1;

--- a/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/activity/BaseTwitterWebViewActivity.java
+++ b/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/activity/BaseTwitterWebViewActivity.java
@@ -49,6 +49,7 @@ import android.webkit.WebView;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 import com.mill_e.twitterwrapper.R;
+import com.mill_e.twitterwrapper.util.AnnoyancesRemover;
 import com.mill_e.twitterwrapper.util.Logger;
 import com.mill_e.twitterwrapper.util.OrbotHelper;
 import com.mill_e.twitterwrapper.util.WebViewProxyUtil;
@@ -111,6 +112,8 @@ public abstract class BaseTwitterWebViewActivity extends Activity implements
     protected ValueCallback<Uri[]> mUploadMessageLollipop = null;
     private boolean mCreatingActivity = true;
     private String mPendingImageUrlToSave = null;
+    protected AnnoyancesRemover mAnnoyancesRemover = null;
+    private boolean blockAndroidAnnoyances;
 
     /**
      * BroadcastReceiver to handle ConnectivityManager.CONNECTIVITY_ACTION intent action.
@@ -173,6 +176,8 @@ public abstract class BaseTwitterWebViewActivity extends Activity implements
 
         // Create a CookieSyncManager instance and keep a reference of it
         mCookieSyncManager = CookieSyncManager.createInstance(this);
+
+        mAnnoyancesRemover = new AnnoyancesRemover();
 
         registerForContextMenu(mWebView);
 
@@ -380,6 +385,15 @@ public abstract class BaseTwitterWebViewActivity extends Activity implements
         if (mWebView != null) {
             mWebView.setAllowGeolocation(allow);
         }
+    }
+
+    /**
+     * Used to set wether to block android related elements from twitters mobile-friendly
+     *
+     * @param block {@link boolean} wether to block these elements
+     */
+    protected void setBlockAnnoyances(boolean block) {
+        blockAndroidAnnoyances = block;
     }
 
     /**
@@ -613,9 +627,12 @@ public abstract class BaseTwitterWebViewActivity extends Activity implements
      * {@inheritDoc}
      */
     @Override
-    public void onPageLoadFinished(String url) {
+    public void onPageLoadFinished(WebView view, String url) {
         Logger.d(LOG_TAG, "onPageLoadFinished() -- url: " + url);
         mProgressBar.setVisibility(View.GONE);
+        if (blockAndroidAnnoyances) {
+            mAnnoyancesRemover.removeAnnoyances(view);
+        }
     }
 
     /**

--- a/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/preferences/TwitterPreferences.java
+++ b/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/preferences/TwitterPreferences.java
@@ -46,6 +46,7 @@ public class TwitterPreferences extends PreferenceActivity {
     public final static String KEY_PROXY_HOST = "prefs_proxy_host";
     public final static String KEY_PROXY_PORT = "prefs_proxy_port";
     public final static String SITE_MODE = "prefs_mobile_site";
+    public final static String KEY_BLOCK_ANDROID_ANNOYANCES = "prefs_block_android_annoyances";
     public final static String SITE_MODE_AUTO = "auto";
     public final static String SITE_MODE_MOBILE = "mobile";
     public final static String SITE_MODE_DESKTOP = "desktop";

--- a/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/util/AnnoyancesRemover.java
+++ b/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/util/AnnoyancesRemover.java
@@ -1,0 +1,40 @@
+package com.mill_e.twitterwrapper.util;
+
+import android.webkit.WebView;
+
+/**
+ * Removes elemens from twitters mobile-friendly site using javascript.
+ *  - "Install Android App" from log in prompt
+ *  - "Install Android App" blue banner in the  "Home" section
+ *  - "Who to Follow" list in the "Home" section
+ *  - "Open App" button in the navigation bar, upper right
+ *
+ *  As the site uses a lot of AJAX, we will just check regularly and
+ *  remove whatever we find. Could be optimized to be easier on the battery.
+ */
+public class AnnoyancesRemover {
+
+    private static final String START = "javascript: window.setInterval(function(){";
+    private static final String END   = "}, 800)";
+    private static final String INSTALL_APP_PROMPT_DURIN_LOGIN = "if(document.title=='Log in'){document.getElementsByTagName('table')[0].innerHTML='';}";
+    private static final String INSTALL_APP_PROMPT             = "document.getElementsByClassName('install-app-prompt-container')[0].innerHTML='';";
+    private static final String INSTALL_WHO_TO_FOLLOW          = "document.getElementsByClassName('wtf')[0].innerHTML='';";
+    private static final String OPEN_APP                       = "document.getElementsByClassName('launchapp')[0].innerHTML='';";
+
+    /**
+     * Remove annoyances from the WebView
+     * @param view
+     */
+    public void removeAnnoyances(WebView view) {
+        view.loadUrl(createJavascript());
+    }
+
+    private String createJavascript() {
+        return START +
+                INSTALL_APP_PROMPT_DURIN_LOGIN +
+                INSTALL_APP_PROMPT +
+                INSTALL_WHO_TO_FOLLOW +
+                OPEN_APP +
+                END;
+    }
+}

--- a/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/webview/TwitterWebViewClient.java
+++ b/Tinfoil-for-Twitter/src/main/java/com/mill_e/twitterwrapper/webview/TwitterWebViewClient.java
@@ -154,7 +154,7 @@ public class TwitterWebViewClient extends WebViewClient {
         super.onPageFinished(view, url);
 
         // Fire the callback
-        fireOnPageFinishedListener(url);
+        fireOnPageFinishedListener(view, url);
     }
 
     /**
@@ -171,11 +171,12 @@ public class TwitterWebViewClient extends WebViewClient {
     /**
      * Fire off the onPageLoadFinished callback.
      *
+     * @param view
      * @param url {@link String} The url that just finished loading.
      */
-    private void fireOnPageFinishedListener(String url) {
+    private void fireOnPageFinishedListener(WebView view, String url) {
         if (mListener != null) {
-            mListener.onPageLoadFinished(url);
+            mListener.onPageLoadFinished(view, url);
         }
     }
 
@@ -206,9 +207,10 @@ public class TwitterWebViewClient extends WebViewClient {
         /**
          * Notify the host activity that a page has finished loading.
          *
+         * @param view
          * @param url {@link String} The url that just finished loading.
          */
-        void onPageLoadFinished(String url);
+        void onPageLoadFinished(WebView view, String url);
 
         /**
          * Notify the host activity that it should hand off this URL

--- a/Tinfoil-for-Twitter/src/main/res/values-de/strings.xml
+++ b/Tinfoil-for-Twitter/src/main/res/values-de/strings.xml
@@ -53,6 +53,7 @@
     <!-- Preferences -->
     <string name="pref_cat_access">Zugriff</string>
     <string name="pref_cat_general">Allgemein</string>
+    <string name="pref_block_annoyances">Lästiges</string>
     <string name="pref_cat_proxy">Proxy</string>
     <string name="prefs_allow_checkins">Einchecken erlauben</string>
     <string name="prefs_allow_checkins_sry">Erlaubt der App, den ungefähren Standort zu benutzen, um mit Facebook einchecken zu können</string>
@@ -66,6 +67,8 @@
     <string name="prefs_mobile_site_sry">Nutzung der Desktop-Version oder verschiedener Mobil-Versionen von Facebook in der App erzwingen.</string>
     <string name="prefs_enable_proxy">Proxy verwenden</string>
     <string name="prefs_enable_proxy_sry">Konfiguriere Proxy-Server für Netzwerkabfragen.</string>
+    <string name="prefs_disable_annoyances">Android bezogene Widgets unterdrücken</string>
+    <string name="prefs_disable_annoyances_sry">\"Adroid App installieren\", \"In der App öffnen\" u.Ä. unterdrücken</string>
     <string name="prefs_proxy_host">Host</string>
     <string name="prefs_proxy_port">Port</string>
 

--- a/Tinfoil-for-Twitter/src/main/res/values/strings.xml
+++ b/Tinfoil-for-Twitter/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <!-- Preferences -->
     <string name="pref_cat_access">Twitter access</string>
     <string name="pref_cat_general">General</string>
+    <string name="pref_block_annoyances">Annoyances</string>
     <string name="pref_cat_proxy">Proxy</string>
     <string name="prefs_allow_checkins">Allow Check-ins</string>
     <string name="prefs_allow_checkins_sry">Allows the mobile app to use coarse location in order to check-in to places</string>
@@ -64,6 +65,8 @@
     <string name="prefs_mobile_site_sry">Force the use of the mobile or desktop site</string>
     <string name="prefs_enable_proxy">Enable proxy</string>
     <string name="prefs_enable_proxy_sry">Configure proxy for network requests.</string>
+    <string name="prefs_disable_annoyances">Disable Android related prompts</string>
+    <string name="prefs_disable_annoyances_sry">\"Install Adroid App\", \"Open App\" and similar buttons will be hidden.</string>
     <string name="prefs_proxy_host">Proxy host</string>
     <string name="prefs_proxy_port">Proxy port</string>
     <string name="pref_logcat">System-Logging</string>

--- a/Tinfoil-for-Twitter/src/main/res/xml/main_preferences.xml
+++ b/Tinfoil-for-Twitter/src/main/res/xml/main_preferences.xml
@@ -45,6 +45,17 @@
 
     </PreferenceCategory>
     <PreferenceCategory
+        android:key="pref_block_annoyances"
+        android:title="@string/pref_block_annoyances" >
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="prefs_block_android_annoyances"
+            android:summary="@string/prefs_disable_annoyances_sry"
+            android:title="@string/prefs_disable_annoyances" />
+
+    </PreferenceCategory>
+    <PreferenceCategory
         android:key="pref_cat_proxy"
         android:title="@string/pref_cat_proxy" >
 


### PR DESCRIPTION
Removes "install app", "open app" and other annoyances from the mobile site. Could be easily extended to remove promoted tweets. Closes tuckervento/Tinfoil-Twitter#1
